### PR TITLE
Fixed log message to show remote network_id

### DIFF
--- a/pyethapp/eth_service.py
+++ b/pyethapp/eth_service.py
@@ -178,7 +178,7 @@ class ChainService(WiredService):
         log.debug('status received', proto=proto, eth_version=eth_version)
         assert eth_version == proto.version, (eth_version, proto.version)
         if network_id != proto.network_id:
-            log.warn("invalid network id", remote_id=proto, network_id=network_id)
+            log.warn("invalid network id", remote_id=proto.network_id, network_id=network_id)
             raise eth_protocol.ETHProtocolError('wrong network_id')
 
         # check genesis


### PR DESCRIPTION
Just made the log message clear. Printing the proto object does not even show remote network_id.